### PR TITLE
Fix #49: Allow rake to run without Rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'acts_as_list',     '0.7.2'
 gem 'platform-api' # Use Heroku API to show update status
 gem 'pry-rails'
 gem 'dotenv-rails', '~> 2.0.1'
+gem 'rubocop',      require: false
 
 # auth
 gem 'devise',             '~> 3.2'
@@ -69,7 +70,6 @@ group :development, :test do
   gem 'spring', '~> 1.3.6'
 
   # linters/debuggers/code checkers
-  gem 'rubocop',  require: false
   gem 'brakeman', require: false
   gem 'bullet'
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,9 +3,12 @@
 # be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new(:lint)
+unless Rails.env.production?
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new(:lint)
+end
+
 Rails.application.load_tasks
 
 task default: %w(test)


### PR DESCRIPTION
- Fix: actually fix error #49–rake can run without requiring Rubocop

Previous pull request only solved Dotenv error